### PR TITLE
remove compile commands flag from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@
     mkdir build && cd build
 
     # For Release
-    cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=On -DCMAKE_BUILD_TYPE=Release
+    cmake .. -DCMAKE_BUILD_TYPE=Release
 
     # OR for Debug (with sanitizers)
-    # cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=On -DCMAKE_BUILD_TYPE=Debug -DENABLE_SANITIZERS=On
+    # cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_SANITIZERS=On
 
     make -j$(nproc)
     ```
@@ -147,7 +147,7 @@ Plugins can be built independently without recompiling the main application.
 **Build Command:**
 ```sh
 cd plugins/my_plugin
-cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=On -DHOST_APP_DIR=../../
+cmake -S . -B build -DHOST_APP_DIR=../../
 cmake --build build
 ```
 


### PR DESCRIPTION
I assume teero uses neovim BTW and needs that for the lsp. Not everyone needs that actually. This is editor specific and not teeframe specific. It pollutes the readme. Neovim users should know how to make their editor work.

Btw @Teero888 I recommend adding this to your shellrc so you never need to pass the flag in any project again:

```sh
export CMAKE_EXPORT_COMPILE_COMMANDS=1
```